### PR TITLE
HFP-3919 Remove title attribute from button

### DIFF
--- a/scripts/go-to-question.js
+++ b/scripts/go-to-question.js
@@ -94,8 +94,7 @@ H5P.GoToQuestion = (function ($, EventDispatcher, UI) {
       // Create continue button
       $continueButton = UI.createButton({
         'class': GoToQuestion.htmlClass + '-continue',
-        html: parameters.continueButtonLabel,
-        title: parameters.continueButtonLabel
+        html: parameters.continueButtonLabel
       });
     };
 


### PR DESCRIPTION
When merged in, will remove the `title` attribute from the continue button that appears in the view if the author set it up to contain a confirmation text.